### PR TITLE
fix “base.KaptContext ” bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.5.32'
+    ext.kotlin_version = '1.6.21'
     Properties properties = new Properties()
     file("local.properties").withInputStream { inputStream ->
         properties.load(inputStream)


### PR DESCRIPTION
android studio 新版本默认执行环境为jdk17，低版本的kotlin-kapt 兼容性有问题，build 时会报错

e: java.lang.IllegalAccessError: class org.jetbrains.kotlin.kapt3.base.KaptContext (in unnamed module @0x5c335e76) cannot access class com.sun.tools.javac.util.Context (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.util to unnamed module @0x5c335e76
     at org.jetbrains.kotlin.kapt3.base.KaptContext.<init>(KaptContext.kt:28)
     at org.jetbrains.kotlin.kapt3.KaptContextForStubGeneration.<init>(KaptContextForStubGeneration.kt:40)
     at org.jetbrains.kotlin.kapt3.AbstractKapt3Extension.contextForStubGeneration(Kapt3Extension.kt:287)
     at org.jetbrains.kotlin.kapt3.AbstractKapt3Extension.analysisCompleted

建议提高默认kotlin的版本号，规避该问题